### PR TITLE
Windows support, misc changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CDEBUGFLAGS = -O -Wmissing-prototypes -Wall -ansi -pedantic
 #CDEBUGFLAGS = -O
 
 # defines (needed for string ops on linux2/glibc for instance):
-DEFINES= -D_XOPEN_SOURCE -D_XOPEN_SOURCE_EXTENDED
+DEFINES= -D_XOPEN_SOURCE -D_XOPEN_SOURCE_EXTENDED -DVERBOSE
 
 # for HPUX (ansi)
 #DEFINES= -D_HPUX_SOURCE

--- a/http.c
+++ b/http.c
@@ -29,8 +29,10 @@ static char *rcsid = "$Id: http.c,v 1.4 1998/09/23 06:11:55 dl Exp $";
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/uio.h>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "http_lib.h"
 
@@ -48,13 +50,13 @@ char **argv;
   }
   i = 1;
 
-  if (!strcasecmp(argv[i], "put")) {
+  if (!strcmp(argv[i], "put")) {
     todo = DOPUT;
-  } else if (!strcasecmp(argv[i], "get")) {
+  } else if (!strcmp(argv[i], "get")) {
     todo = DOGET;
-  } else if (!strcasecmp(argv[i], "delete")) {
+  } else if (!strcmp(argv[i], "delete")) {
     todo = DODEL;
-  } else if (!strcasecmp(argv[i], "head")) {
+  } else if (!strcmp(argv[i], "head")) {
     todo = DOHEA;
   }
   if (todo == ERR) {
@@ -79,6 +81,11 @@ char **argv;
     if (proxy)
       free(http_proxy_server);
     return ret;
+  }
+
+  if (!http_init()) {
+    fprintf(stderr, "Failed to initialize http subsystem\n");
+    return 1;
   }
 
   switch (todo) {

--- a/http_lib.c
+++ b/http_lib.c
@@ -68,8 +68,6 @@ extern char *malloc();
 
 #include "http_lib.h"
 
-#define SERVER_DEFAULT "adonis"
-
 /* pointer to a mallocated string containing server name or NULL */
 char *http_server = NULL;
 /* server port number */
@@ -177,10 +175,11 @@ int *pfd;   /* pointer to variable where to set file descriptor value */
   if (pfd)
     *pfd = -1;
 
+  if (!http_server)
+    return ERRHOST;
+
   /* get host info by name :*/
-  if ((hp = gethostbyname(
-           proxy ? http_proxy_server
-                 : (http_server ? http_server : SERVER_DEFAULT)))) {
+  if ((hp = gethostbyname(proxy ? http_proxy_server : http_server))) {
     memset((char *)&server, 0, sizeof(server));
     memmove((char *)&server.sin_addr, hp->h_addr_list[0], hp->h_length);
     server.sin_family = hp->h_addrtype;
@@ -203,14 +202,15 @@ int *pfd;   /* pointer to variable where to set file descriptor value */
     /* create header */
     if (proxy) {
       sprintf(header,
-              "%s http://%.128s:%d/%.256s HTTP/1.0\015\012User-Agent: "
-              "%s\015\012%s\015\012",
-              command, http_server, http_port, url, http_user_agent,
-              additional_header);
+              "%s http://%.128s:%d/%.256s HTTP/1.0\015\012Host: %s\015\012"
+              "User-Agent: %s\015\012%s\015\012",
+              command, http_server, http_port, url, http_server,
+              http_user_agent, additional_header);
     } else {
       sprintf(header,
-              "%s /%.256s HTTP/1.0\015\012User-Agent: %s\015\012%s\015\012",
-              command, url, http_user_agent, additional_header);
+              "%s /%.256s HTTP/1.0\015\012Host: %s\015\012User-Agent: %s"
+              "\015\012%s\015\012",
+              command, url, http_server, http_user_agent, additional_header);
     }
 
     hlg = strlen(header);

--- a/http_lib.c
+++ b/http_lib.c
@@ -33,8 +33,6 @@
 
 static char *rcsid = "$Id: http_lib.c,v 3.5 1998/09/23 06:19:15 dl Exp $";
 
-#define VERBOSE
-
 /* http_lib - Http data exchanges mini library.
  */
 

--- a/http_lib.c
+++ b/http_lib.c
@@ -182,7 +182,7 @@ int *pfd;   /* pointer to variable where to set file descriptor value */
            proxy ? http_proxy_server
                  : (http_server ? http_server : SERVER_DEFAULT)))) {
     memset((char *)&server, 0, sizeof(server));
-    memmove((char *)&server.sin_addr, hp->h_addr, hp->h_length);
+    memmove((char *)&server.sin_addr, hp->h_addr_list[0], hp->h_length);
     server.sin_family = hp->h_addrtype;
     server.sin_port = (unsigned short)htons(port);
   } else

--- a/http_lib.h
+++ b/http_lib.h
@@ -55,6 +55,9 @@ typedef enum {
 /* prototypes */
 
 #ifndef OSK
+int http_init(void);
+void http_shutdown(void);
+
 http_retcode http_put(char *filename, char *data, int length, int overwrite,
                       char *type);
 http_retcode http_get(char *filename, char **pdata, int *plength,


### PR DESCRIPTION
Hey Laurent,

I was looking for a simple lib to do cross-platform HTTP get requests and ran into this last night - what a nice piece of code.

I made a few changes to get it to support my needs which I've mashed together all into this single PR.

The primary changes:

* Replace use of h_addr with h_addr_list[0]. h_addr_list is part of the POSIX spec nowadays (http://pubs.opengroup.org/onlinepubs/009695399/basedefs/netdb.h.html) with h_addr requiring various preprocessor defines to support, all of which ultimately just define it as h_addr_list[0].
* Added Host header to requests. Many of my GET requests were netting me 403's without specifying this.
* Added support for Windows. While doing this, I got rid of uses of strcasecmp rather than defining it to be _strcimp on Windows in the interest of adding as little code as possible. Additionally, I've added these somewhat silly http_init / http_shutdown methods as a convenience to users, but it could be assumed that Windows users will have already initialized Winsock (and the code could then just be moved into http.c). Finally, I didn't actually call http_shutdown in http.c to avoid making more changes than necessary to the control flow in there.
